### PR TITLE
Allow multi-user on Windows

### DIFF
--- a/run_windows.bat
+++ b/run_windows.bat
@@ -1,1 +1,2 @@
-assets\python\python.exe assets\game.py
+@pushd %USERPROFILE%
+%~dp0\assets\python\python.exe %~dp0\assets\game.py

--- a/uninstall_windows.bat
+++ b/uninstall_windows.bat
@@ -1,4 +1,5 @@
 @echo off
+@pushd %USERPROFILE%
 echo Deleting generated files...
 rd /s /q .game
 echo Done! You can now just delete this folder


### PR DESCRIPTION
Puts game in user home dir instead of application dir. Allows multiple people on one machine, or from a server share, and users don't need write access to the app dir.